### PR TITLE
fix: handle eglot diagnostic types

### DIFF
--- a/sideline-flymake.el
+++ b/sideline-flymake.el
@@ -73,6 +73,8 @@ Argument COMMAND is required in sideline backend."
         (let* ((text (flymake-diagnostic-text err))
                (type (flymake-diagnostic-type err))
                (face (cl-case type
+                       ('eglot-error 'error)
+                       ('eglot-warning 'warning)
                        (:error 'error)
                        (:warning 'warning)
                        (t 'success))))


### PR DESCRIPTION
Eglot diagnostics return these values `flymake-diagnotic-type`, so this gives us correct highlighting.

This is the same code change from #1 