### PR TITLE
match `sideline--do-render-p` conditions in `--get-errors`

### DIFF
--- a/sideline-flymake.el
+++ b/sideline-flymake.el
@@ -112,7 +112,9 @@ Argument COMMAND is required in sideline backend."
 (defun sideline-flymake--get-errors ()
   "Return flymake errors."
   (cl-case sideline-flymake-display-mode
-    (`point (flymake-diagnostics (point)))
+    (`point (if-let* ((bounds (bounds-of-thing-at-point 'symbol)))
+                (flymake-diagnostics (car bounds) (cdr bounds))
+              (flymake-diagnostics (point))))
     (`line (flymake-diagnostics (line-beginning-position) (line-end-position)))
     (t (user-error "Invalid value of `sideline-flymake-display-mode': %s"
                    sideline-flymake-display-mode))))


### PR DESCRIPTION
This makes sure that the sideline correctly updates with the error at point when moving leftwards inside a line. Previously, the Flymake error would not show up when moving leftwards.

Before:
![output-2025-03-30-17:16:24](https://github.com/user-attachments/assets/e7b13f92-0d91-44da-9a36-6f21e8771d14)

After:
![output-2025-03-30-17:16:02](https://github.com/user-attachments/assets/5cd18b3d-ae34-495b-8d2a-0e73a3980379)
